### PR TITLE
Add tests for tips calculators

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "gh-pages": "^2.2.0"
+    "gh-pages": "^2.2.0",
+    "@testing-library/react": "^14.0.0"
   }
 }

--- a/src/components/Home/__tests__/Placeholder.test.js
+++ b/src/components/Home/__tests__/Placeholder.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Placeholder from '../Placeholder';
+import { StorageContext } from '../storageContext';
+
+describe('Placeholder', () => {
+  test('sums inputs and calls guardarTips', () => {
+    const guardarTips = jest.fn();
+    const contextValue = {
+      tips: 0,
+      guardarTips,
+      split: [],
+      guardarSplit: jest.fn()
+    };
+    const { container, getByText } = render(
+      <StorageContext.Provider value={contextValue}>
+        <Placeholder />
+      </StorageContext.Provider>
+    );
+    const cashInput = container.querySelector('#amount-Cash');
+    const cardInput = container.querySelector('#amount-Cards');
+
+    fireEvent.change(cashInput, { target: { value: '5' } });
+    fireEvent.change(cardInput, { target: { value: '7' } });
+
+    fireEvent.click(getByText('Summit'));
+
+    expect(guardarTips).toHaveBeenCalledWith(12);
+  });
+});

--- a/src/components/Home/__tests__/Staff.test.js
+++ b/src/components/Home/__tests__/Staff.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Staff from '../Staff';
+import { StorageContext } from '../storageContext';
+import { TipsContext } from '../../Staff/tipsContext';
+
+describe('Staff component', () => {
+  beforeEach(() => {
+    localStorage.setItem('valorTotal', '5');
+  });
+
+  test('displays calculated shares', () => {
+    const storageValue = {
+      tips: 100,
+      guardarTips: jest.fn(),
+      split: [],
+      guardarSplit: jest.fn()
+    };
+    const tipsValue = { valorFinal: 0 };
+
+    const { container } = render(
+      <TipsContext.Provider value={tipsValue}>
+        <StorageContext.Provider value={storageValue}>
+          <Staff />
+        </StorageContext.Provider>
+      </TipsContext.Provider>
+    );
+
+    const text = container.textContent;
+    expect(text).toContain('$19.00');
+    expect(text).toContain('$14.00');
+    expect(text).toContain('$9.00');
+    expect(text).toContain('$5.00');
+    expect(text).toContain('-101');
+  });
+});

--- a/src/components/Staff/__tests__/SplitList.test.js
+++ b/src/components/Staff/__tests__/SplitList.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import SplitList from '../SplitList';
+import TipsContextProvider from '../tipsContext';
+
+describe('SplitList', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('stores calculated value in localStorage', () => {
+    const { container, getByText } = render(
+      <TipsContextProvider>
+        <SplitList />
+      </TipsContextProvider>
+    );
+
+    const buttons = container.querySelectorAll('button');
+    fireEvent.click(buttons[0]);  // waiter 1
+    fireEvent.click(buttons[7]);  // food runner 1
+    fireEvent.click(buttons[14]); // busboys 1
+
+    fireEvent.click(getByText('Summit'));
+
+    expect(parseFloat(localStorage.getItem('valorTotal'))).toBeCloseTo(2.25);
+  });
+});


### PR DESCRIPTION
## Summary
- add `@testing-library/react` dev dependency
- test cash/card form for saving tips
- test staff splitting list
- test staff calculations

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new test suites for the Placeholder, Staff, and SplitList components to verify correct calculations and interactions.
- **Chores**
  - Added "@testing-library/react" as a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->