### PR TITLE
Fix nav links to use Link component

### DIFF
--- a/src/components/Home/nav.js
+++ b/src/components/Home/nav.js
@@ -1,18 +1,19 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 const Nav = () => {
   return (
     <div className="ui three item menu">
-      <a href="/Home" className="item active">
+      <Link to="/Home" className="item active">
         Summary
-      </a>
+      </Link>
 
-      <a href="SplitList" className="item">
+      <Link to="/SplitList" className="item">
         Split
-      </a>
-      <a href="/CalculatorImage" className="item">
+      </Link>
+      <Link to="/CalculatorImage" className="item">
         Calculator
-      </a>
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- use `Link` from `react-router-dom` instead of anchor tags in navigation

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated navigation links to use client-side routing for smoother transitions within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->